### PR TITLE
Edit task enqueue, sequence ID, and websocket improvements

### DIFF
--- a/app/agents/tool_agents/create_tasks_tool_agent.py
+++ b/app/agents/tool_agents/create_tasks_tool_agent.py
@@ -2,7 +2,7 @@ import json
 import uuid
 from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
-from database import execute_update
+from database import execute_update, update_task_enqueue_sequence_id
 from psycopg2.extras import Json
 
 from ..gemini_client import call_gemini, gemini_response_to_openai_like
@@ -218,10 +218,7 @@ class CreateTasksToolAgent:
                 # Persist Service Bus sequence_id to task row when present (scheduled messages only)
                 if enqueue_result and enqueue_result.get("sequence_id") is not None:
                     try:
-                        execute_update(
-                            'UPDATE tasks SET enqueue_sequence_id = %s WHERE task_id = %s',
-                            (enqueue_result["sequence_id"], task_id)
-                        )
+                        update_task_enqueue_sequence_id(task_id, enqueue_result["sequence_id"])
                     except Exception as update_err:
                         print(f"Warning: Failed to update enqueue_sequence_id for task {task_id}: {update_err}")
             except Exception as e:

--- a/app/agents/tool_agents/create_tasks_tool_agent.py
+++ b/app/agents/tool_agents/create_tasks_tool_agent.py
@@ -215,6 +215,15 @@ class CreateTasksToolAgent:
                     time_to_execute=time_to_execute.isoformat()
                 )
                 print(f"Task enqueued to Service Bus: {enqueue_result}")
+                # Persist Service Bus sequence_id to task row when present (scheduled messages only)
+                if enqueue_result and enqueue_result.get("sequence_id") is not None:
+                    try:
+                        execute_update(
+                            'UPDATE tasks SET enqueue_sequence_id = %s WHERE task_id = %s',
+                            (enqueue_result["sequence_id"], task_id)
+                        )
+                    except Exception as update_err:
+                        print(f"Warning: Failed to update enqueue_sequence_id for task {task_id}: {update_err}")
             except Exception as e:
                 print(f"Warning: Failed to enqueue task to Service Bus: {e}")
                 # Continue even if enqueueing fails - task is already in database

--- a/app/agents/tool_agents/edit_tasks_tool_agent.py
+++ b/app/agents/tool_agents/edit_tasks_tool_agent.py
@@ -5,6 +5,14 @@ from database import execute_query, execute_update
 from psycopg2.extras import Json
 
 from ..gemini_client import call_gemini, gemini_response_to_openai_like
+try:
+    from enqueue.edit_task_enqueue import (
+        reenqueue_task_after_edit_safe,
+        cancel_scheduled_task_for_task_id_safe,
+    )
+except ImportError:
+    reenqueue_task_after_edit_safe = None
+    cancel_scheduled_task_for_task_id_safe = None
 from ..utils.task_extraction_utils import extract_tasks_from_chat_history
 
 class EditTasksToolAgent:
@@ -370,6 +378,25 @@ class EditTasksToolAgent:
             
             updated_task = dict(updated_tasks[0])
             
+            # Service Bus: cancel existing scheduled message and/or re-enqueue with updated payload
+            if cancel_scheduled_task_for_task_id_safe and new_status == "completed":
+                cancel_scheduled_task_for_task_id_safe(task_id, user_id)
+            elif reenqueue_task_after_edit_safe and (new_time_to_execute_str or new_task_info) and updated_task.get("status") == "pending":
+                time_to_execute_iso = updated_task.get("time_to_execute")
+                if time_to_execute_iso is not None and hasattr(time_to_execute_iso, "isoformat"):
+                    time_to_execute_iso = time_to_execute_iso.isoformat()
+                elif time_to_execute_iso is not None:
+                    time_to_execute_iso = str(time_to_execute_iso)
+                try:
+                    reenqueue_task_after_edit_safe(
+                        task_id=task_id,
+                        user_id=user_id,
+                        task_info=updated_task.get("task_info"),
+                        time_to_execute=time_to_execute_iso,
+                    )
+                except Exception as e:
+                    print(f"Warning: Failed to re-enqueue task after edit: {e}")
+
             # Convert datetime to ISO format if present
             task_info = updated_task.get("task_info")
             time_to_execute = updated_task.get("time_to_execute")

--- a/app/agents/tool_agents/edit_tasks_tool_agent.py
+++ b/app/agents/tool_agents/edit_tasks_tool_agent.py
@@ -5,14 +5,12 @@ from database import execute_query, execute_update
 from psycopg2.extras import Json
 
 from ..gemini_client import call_gemini, gemini_response_to_openai_like
-try:
-    from enqueue.edit_task_enqueue import (
-        reenqueue_task_after_edit_safe,
-        cancel_scheduled_task_for_task_id_safe,
-    )
-except ImportError:
-    reenqueue_task_after_edit_safe = None
-    cancel_scheduled_task_for_task_id_safe = None
+
+from enqueue.edit_task_enqueue import (
+    reenqueue_task_after_edit_safe,
+    cancel_scheduled_task_for_task_id_safe,
+)
+
 from ..utils.task_extraction_utils import extract_tasks_from_chat_history
 
 class EditTasksToolAgent:

--- a/app/database.py
+++ b/app/database.py
@@ -115,6 +115,23 @@ def get_user_timezone(user_id: str) -> str:
     return "UTC"
 
 
+def update_task_enqueue_sequence_id(task_id: str, sequence_id) -> int:
+    """
+    Update the enqueue_sequence_id for a task (e.g. after enqueueing to Service Bus).
+
+    Args:
+        task_id: The task ID to update
+        sequence_id: The sequence ID from the queue (e.g. Service Bus)
+
+    Returns:
+        Number of rows affected
+    """
+    return execute_update(
+        "UPDATE tasks SET enqueue_sequence_id = %s WHERE task_id = %s",
+        (sequence_id, task_id),
+    )
+
+
 def get_user_by_id(user_id: str) -> dict:
     """
     Get full user profile by user_id.

--- a/app/enqueue/edit_task_enqueue.py
+++ b/app/enqueue/edit_task_enqueue.py
@@ -1,0 +1,149 @@
+"""
+Edit-task enqueue operations module.
+Cancels the existing scheduled message (by sequence_id from the task table) and
+re-enqueues a new message with updated time / info / payload using the same format as task_enqueue.
+"""
+from typing import Optional, Dict, Any
+
+from database import execute_query, execute_update
+from enqueue.task_enqueue import get_service_bus_client, enqueue_task
+
+
+def reenqueue_task_after_edit(
+    task_id: str,
+    user_id: str,
+    task_info: Optional[Dict[str, Any]] = None,
+    time_to_execute: Optional[str] = None,
+    queue_name: str = "q1",
+) -> Dict[str, Any]:
+    """
+    Look up the task's enqueue_sequence_id in the SQL table, cancel that scheduled
+    message in Service Bus, then enqueue a new message with the updated time/info/payload.
+
+    Uses the same message format as task_enqueue (prepare_message_contents, enqueue_task).
+
+    Args:
+        task_id: The task ID
+        user_id: The user ID (must match task row)
+        task_info: Updated task information dict (e.g. {"info": "description"})
+        time_to_execute: Updated ISO 8601 datetime string for scheduled delivery
+        queue_name: Service Bus queue name (default: "q1")
+
+    Returns:
+        Enqueue result dict from enqueue_task (success, task_id, scheduled_time, sequence_id, ...)
+
+    Raises:
+        ValueError: If task not found or Service Bus not configured
+    """
+    # Load current enqueue_sequence_id from tasks table
+    query = """
+        SELECT enqueue_sequence_id
+        FROM tasks
+        WHERE task_id = %s AND user_id = %s
+    """
+    rows = execute_query(query, (task_id, user_id))
+    if not rows:
+        raise ValueError(f"Task not found: task_id={task_id}, user_id={user_id}")
+
+    enqueue_sequence_id = rows[0].get("enqueue_sequence_id") if rows else None
+
+    # Cancel existing scheduled message if we have a sequence number
+    if enqueue_sequence_id is not None:
+        with get_service_bus_client() as client:
+            with client.get_queue_sender(queue_name) as sender:
+                sender.cancel_scheduled_messages(enqueue_sequence_id)
+                print(f"✅ Cancelled scheduled message for task {task_id} (sequence_id={enqueue_sequence_id})")
+
+    # Enqueue new message with updated payload (same format as task_enqueue)
+    result = enqueue_task(
+        task_id=task_id,
+        user_id=user_id,
+        task_info=task_info,
+        time_to_execute=time_to_execute,
+        queue_name=queue_name,
+    )
+
+    # Persist new sequence_id to task row when present (scheduled messages only)
+    if result.get("sequence_id") is not None:
+        try:
+            execute_update(
+                "UPDATE tasks SET enqueue_sequence_id = %s WHERE task_id = %s",
+                (result["sequence_id"], task_id),
+            )
+        except Exception as update_err:
+            print(f"Warning: Failed to update enqueue_sequence_id for task {task_id}: {update_err}")
+
+    return result
+
+
+def cancel_scheduled_task_for_task_id(
+    task_id: str,
+    user_id: str,
+    queue_name: str = "q1",
+) -> bool:
+    """
+    Look up the task's enqueue_sequence_id and cancel that scheduled message in Service Bus.
+    Also sets enqueue_sequence_id to NULL in the task row. Use when e.g. task is marked completed.
+
+    Returns:
+        True if a message was cancelled (or no sequence_id was stored), False if task not found.
+    """
+    query = """
+        SELECT enqueue_sequence_id
+        FROM tasks
+        WHERE task_id = %s AND user_id = %s
+    """
+    rows = execute_query(query, (task_id, user_id))
+    if not rows:
+        return False
+
+    enqueue_sequence_id = rows[0].get("enqueue_sequence_id") if rows else None
+    if enqueue_sequence_id is None:
+        return True  # Nothing to cancel
+
+    with get_service_bus_client() as client:
+        with client.get_queue_sender(queue_name) as sender:
+            sender.cancel_scheduled_messages(enqueue_sequence_id)
+            print(f"✅ Cancelled scheduled message for task {task_id} (sequence_id={enqueue_sequence_id})")
+
+    execute_update(
+        "UPDATE tasks SET enqueue_sequence_id = NULL WHERE task_id = %s",
+        (task_id,),
+    )
+    return True
+
+
+def cancel_scheduled_task_for_task_id_safe(
+    task_id: str,
+    user_id: str,
+    queue_name: str = "q1",
+) -> bool:
+    """Non-raising version of cancel_scheduled_task_for_task_id. Returns False on error."""
+    try:
+        return cancel_scheduled_task_for_task_id(task_id, user_id, queue_name)
+    except Exception as e:
+        print(f"Warning: Failed to cancel scheduled message for task {task_id}: {e}")
+        return False
+
+
+def reenqueue_task_after_edit_safe(
+    task_id: str,
+    user_id: str,
+    task_info: Optional[Dict[str, Any]] = None,
+    time_to_execute: Optional[str] = None,
+    queue_name: str = "q1",
+) -> Optional[Dict[str, Any]]:
+    """
+    Non-raising version of reenqueue_task_after_edit. Returns None on error.
+    """
+    try:
+        return reenqueue_task_after_edit(
+            task_id=task_id,
+            user_id=user_id,
+            task_info=task_info,
+            time_to_execute=time_to_execute,
+            queue_name=queue_name,
+        )
+    except Exception as e:
+        print(f"Warning: Failed to re-enqueue task {task_id} after edit: {e}")
+        return None

--- a/app/enqueue/task_enqueue.py
+++ b/app/enqueue/task_enqueue.py
@@ -118,7 +118,9 @@ def enqueue_task(
         queue_name: Name of the Service Bus queue (default: "q1")
         
     Returns:
-        Dictionary with success status and scheduling information
+        Dictionary with success status, scheduling information, and optional sequence_id.
+        For scheduled messages, sequence_id is the Service Bus 64-bit sequence number (int).
+        For immediate send, sequence_id is None (API does not return it).
         
     Raises:
         ValueError: If Service Bus is not configured or connection fails
@@ -149,24 +151,28 @@ def enqueue_task(
                 message = ServiceBusMessage(message_content)
                 
                 if scheduled_time:
-                    # Schedule the message for future delivery
-                    sender.schedule_messages(message, scheduled_time)
-                    print(f"✅ Task {task_id} scheduled for {scheduled_time.strftime('%Y-%m-%d %H:%M:%S UTC')}")
+                    # Schedule the message for future delivery.
+                    # schedule_messages returns List[int] of sequence numbers (one per message).
+                    sequence_numbers = sender.schedule_messages(message, scheduled_time)
+                    sequence_id = sequence_numbers[0] if sequence_numbers else None
+                    print(f"✅ Task {task_id} scheduled for {scheduled_time.strftime('%Y-%m-%d %H:%M:%S UTC')}" + (f" (sequence_id={sequence_id})" if sequence_id is not None else ""))
                     return {
                         "success": True,
                         "task_id": task_id,
                         "scheduled_time": scheduled_time.isoformat(),
-                        "message": f"Task scheduled for {scheduled_time.strftime('%Y-%m-%d %H:%M:%S UTC')}"
+                        "message": f"Task scheduled for {scheduled_time.strftime('%Y-%m-%d %H:%M:%S UTC')}",
+                        "sequence_id": sequence_id,
                     }
                 else:
-                    # Send immediately
+                    # Send immediately. send_messages returns None (no sequence number in API).
                     sender.send_messages(message)
                     print(f"✅ Task {task_id} enqueued immediately")
                     return {
                         "success": True,
                         "task_id": task_id,
                         "scheduled_time": None,
-                        "message": "Task enqueued immediately"
+                        "message": "Task enqueued immediately",
+                        "sequence_id": None,
                     }
                     
     except Exception as e:

--- a/app/routes/task_crud.py
+++ b/app/routes/task_crud.py
@@ -9,11 +9,19 @@ from datetime import datetime
 from database import execute_query, execute_update, get_db_connection
 import psycopg2
 
-# Import enqueue function (with safe import to avoid circular dependencies)
+# Import enqueue functions (with safe import to avoid circular dependencies)
 try:
     from enqueue.task_enqueue import enqueue_task_safe
 except ImportError:
     enqueue_task_safe = None
+try:
+    from enqueue.edit_task_enqueue import (
+        reenqueue_task_after_edit_safe,
+        cancel_scheduled_task_for_task_id_safe,
+    )
+except ImportError:
+    reenqueue_task_after_edit_safe = None
+    cancel_scheduled_task_for_task_id_safe = None
 
 
 def get_tasks_by_user_id(user_id: str) -> List[Dict[str, Any]]:
@@ -28,7 +36,7 @@ def get_tasks_by_user_id(user_id: str) -> List[Dict[str, Any]]:
     """
     try:
         query = """
-            SELECT task_id, user_id, task_info, status, time_to_execute
+            SELECT task_id, user_id, task_info, status, time_to_execute, enqueue_sequence_id
             FROM tasks
             WHERE user_id = %s
             ORDER BY time_to_execute ASC NULLS LAST, task_id DESC
@@ -43,7 +51,8 @@ def get_tasks_by_user_id(user_id: str) -> List[Dict[str, Any]]:
                 "user_id": row["user_id"],
                 "task_info": row["task_info"] if row["task_info"] else None,
                 "status": row["status"],
-                "time_to_execute": row["time_to_execute"].isoformat() if row["time_to_execute"] else None
+                "time_to_execute": row["time_to_execute"].isoformat() if row["time_to_execute"] else None,
+                "enqueue_sequence_id": row.get("enqueue_sequence_id"),
             }
             tasks.append(task)
         
@@ -65,7 +74,7 @@ def get_task_by_id(task_id: str) -> Optional[Dict[str, Any]]:
     """
     try:
         query = """
-            SELECT task_id, user_id, task_info, status, time_to_execute
+            SELECT task_id, user_id, task_info, status, time_to_execute, enqueue_sequence_id
             FROM tasks
             WHERE task_id = %s
         """
@@ -80,7 +89,8 @@ def get_task_by_id(task_id: str) -> Optional[Dict[str, Any]]:
             "user_id": row["user_id"],
             "task_info": row["task_info"] if row["task_info"] else None,
             "status": row["status"],
-            "time_to_execute": row["time_to_execute"].isoformat() if row["time_to_execute"] else None
+            "time_to_execute": row["time_to_execute"].isoformat() if row["time_to_execute"] else None,
+            "enqueue_sequence_id": row.get("enqueue_sequence_id"),
         }
     except Exception as e:
         print(f"Error fetching task: {e}")
@@ -149,6 +159,15 @@ def create_task(
                 )
                 if enqueue_result:
                     task["enqueue_result"] = enqueue_result
+                    # Persist Service Bus sequence_id to task row when present (scheduled messages only)
+                    if enqueue_result.get("sequence_id") is not None:
+                        try:
+                            execute_update(
+                                "UPDATE tasks SET enqueue_sequence_id = %s WHERE task_id = %s",
+                                (enqueue_result["sequence_id"], task_id)
+                            )
+                        except Exception as update_err:
+                            print(f"Warning: Failed to update enqueue_sequence_id for task {task_id}: {update_err}")
                 else:
                     task["enqueue_warning"] = "Task created but enqueue failed (see server logs)"
             except Exception as e:
@@ -171,7 +190,8 @@ def update_task(
     task_id: str,
     task_info: Optional[Dict[str, Any]] = None,
     status: Optional[str] = None,
-    time_to_execute: Optional[str] = None
+    time_to_execute: Optional[str] = None,
+    reenqueue: bool = False,
 ) -> Dict[str, Any]:
     """
     Update an existing task.
@@ -181,6 +201,9 @@ def update_task(
         task_info: Optional task information dictionary to update
         status: Optional task status to update
         time_to_execute: Optional ISO 8601 datetime string to update
+        reenqueue: If True, cancel existing Service Bus scheduled message and re-enqueue
+                  with updated payload when time_to_execute or task_info changed; or
+                  cancel only when status is set to completed.
         
     Returns:
         Updated task dictionary
@@ -230,6 +253,23 @@ def update_task(
         updated_task = get_task_by_id(task_id)
         if updated_task is None:
             raise ValueError("Task not found after update")
+        
+        # Optionally sync Service Bus: cancel and/or re-enqueue with updated payload
+        if reenqueue and (reenqueue_task_after_edit_safe is not None or cancel_scheduled_task_for_task_id_safe is not None):
+            user_id = updated_task.get("user_id")
+            if user_id:
+                if status == "completed" and cancel_scheduled_task_for_task_id_safe:
+                    cancel_scheduled_task_for_task_id_safe(task_id, user_id)
+                elif (task_info is not None or time_to_execute is not None) and updated_task.get("status") != "completed" and reenqueue_task_after_edit_safe:
+                    time_iso = updated_task.get("time_to_execute")
+                    if hasattr(time_iso, "isoformat"):
+                        time_iso = time_iso.isoformat()
+                    reenqueue_task_after_edit_safe(
+                        task_id=task_id,
+                        user_id=user_id,
+                        task_info=updated_task.get("task_info"),
+                        time_to_execute=time_iso,
+                    )
         
         return updated_task
     except psycopg2.Error as e:

--- a/app/routes/task_crud.py
+++ b/app/routes/task_crud.py
@@ -10,19 +10,13 @@ from database import execute_query, execute_update, get_db_connection
 import psycopg2
 
 # Import enqueue functions (with safe import to avoid circular dependencies)
-try:
-    from enqueue.task_enqueue import enqueue_task_safe
-except ImportError:
-    enqueue_task_safe = None
-try:
-    from enqueue.edit_task_enqueue import (
+
+from enqueue.task_enqueue import enqueue_task_safe
+
+from enqueue.edit_task_enqueue import (
         reenqueue_task_after_edit_safe,
         cancel_scheduled_task_for_task_id_safe,
     )
-except ImportError:
-    reenqueue_task_after_edit_safe = None
-    cancel_scheduled_task_for_task_id_safe = None
-
 
 def get_tasks_by_user_id(user_id: str) -> List[Dict[str, Any]]:
     """

--- a/app/websocket_handler.py
+++ b/app/websocket_handler.py
@@ -290,7 +290,6 @@ async def websocket_endpoint(websocket: WebSocket, user_id: str):
                 # Flag to track if we should close after receiving the goodbye audio
                 should_close_after_audio = False
                 last_audio_received_time = None
-                
                 while True:
                     async for response in gemini_session.receive():
                         # retrieve continuously resumable session ID (identical to working example)
@@ -353,24 +352,26 @@ async def websocket_endpoint(websocket: WebSocket, user_id: str):
                                             processed_tool_inputs.add(normalized_input)
                                             # Call think_and_repeat_output function in a separate thread to avoid blocking the event loop
                                             # This allows the agent to continue processing audio (like "One moment") while thinking
-                                            result = await asyncio.to_thread(
-                                                generalThinkingAgent.think, 
-                                                user_input, 
-                                                scratchpad.get_entries(), 
-                                                user_config
-                                            )
-                                            print(f"generalThinkingAgent.think(user_input) {result}")
-                                            
-                                            # Handle both string (error/duplicate) and dict (success) returns
-                                            if isinstance(result, dict):
-                                                return_string = result.get("result", "")
-                                            else:
-                                                return_string = str(result)
-                                                
+                                            try:
+                                                result = await asyncio.to_thread(
+                                                    generalThinkingAgent.think,
+                                                    user_input,
+                                                    scratchpad.get_entries(),
+                                                    user_config
+                                                )
+                                                print(f"✅ think() finished: {str(result)[:80]}...")
+                                                # Handle both string (error/duplicate) and dict (success) returns
+                                                if isinstance(result, dict):
+                                                    return_string = result.get("result", "")
+                                                else:
+                                                    return_string = str(result)
+                                            except Exception as e:
+                                                print(f"⚠️ think() failed: {e}")
+                                                traceback.print_exc()
+                                                return_string = "Sorry, something went wrong while processing that. Please try again."
                                             # Ensure we end with a period if not present, for better TTS
                                             if return_string and not return_string.endswith('.'):
                                                 return_string += "."
-                                                
                                             function_responses.append(
                                                 {
                                                     "name": name,
@@ -406,8 +407,9 @@ async def websocket_endpoint(websocket: WebSocket, user_id: str):
 
                             # Send function responses back to Gemini (only if we have actual responses)
                             if function_responses:
-                                print(f"Sending function responses: {function_responses}")
-                                print(f"function_responses: {function_responses[0]['response']}")
+                                print(f"📤 Sending tool response to Gemini ({len(function_responses)} response(s))...")
+                                first_result = function_responses[0].get("response", {}).get("result", "")
+                                print(f"   result preview: {(first_result[:80] + '...') if len(first_result) > 80 else first_result}")
                                 
                                 # Add function responses to scratchpad
                                 for func_response in function_responses:
@@ -518,11 +520,9 @@ async def websocket_endpoint(websocket: WebSocket, user_id: str):
             # Use TaskGroup to manage all the concurrent tasks
             try:
                 async with asyncio.TaskGroup() as tg:
-                    # Start all tasks within the TaskGroup context
                     tg.create_task(ws_reader())
                     tg.create_task(process_and_send_audio())
                     tg.create_task(receive_and_play())
-                    
                     # The TaskGroup will wait for all tasks to complete
                     # This ensures proper cleanup when the WebSocket connection ends
             except* Exception as eg:

--- a/test/app/agents/test_helpers.py
+++ b/test/app/agents/test_helpers.py
@@ -37,7 +37,7 @@ def get_today_date_strings():
     return today, today_readable
 
 
-def create_mock_enqueue_result(task_id=None, scheduled_time=None, success=True):
+def create_mock_enqueue_result(task_id=None, scheduled_time=None, success=True, sequence_id=12345):
     """
     Create a mock enqueue result dictionary.
     
@@ -45,6 +45,7 @@ def create_mock_enqueue_result(task_id=None, scheduled_time=None, success=True):
         task_id: Optional task ID (if None, will need to be set later)
         scheduled_time: Optional scheduled time (if None, will need to be set later)
         success: Whether the enqueue was successful (default: True)
+        sequence_id: Optional Service Bus sequence number (default: 12345); None for immediate send
     
     Returns:
         dict: Mock enqueue result
@@ -53,7 +54,8 @@ def create_mock_enqueue_result(task_id=None, scheduled_time=None, success=True):
         "success": success,
         "task_id": task_id,
         "scheduled_time": scheduled_time,
-        "message": "Task scheduled successfully" if success else "Task scheduling failed"
+        "message": "Task scheduled successfully" if success else "Task scheduling failed",
+        "sequence_id": sequence_id,
     }
 
 


### PR DESCRIPTION
1. Update create task tool to insert the sequence ID when creating tasks.

2. During edit task: cancel service bus if task is marked complete; otherwise if task is not past execution time, cancel the service bus message and re-enqueue a new task.

3. Add new edit_task_enqueue module in enqueue folder.