### PR TITLE
Point test WebSocket clients at Azure App Service (dual-stack)

### DIFF
--- a/test/app/test_pending_message.py
+++ b/test/app/test_pending_message.py
@@ -53,8 +53,9 @@ USE_IOT_HUB_INIT = os.getenv("USE_IOT_HUB_INIT", "1").lower() in ("1", "true", "
 # Chat to attach the test message to (must exist or use a test-only chat_id)
 TEST_CHAT_ID = os.getenv("TEST_PENDING_CHAT_ID", "550e8400-e29b-41d4-a716-446655440000")
 WS_URI = (
-    f"ws://localhost:8000/ws/{USER_ID}"
-    # f"wss://websocket-ai-pin.bluesmoke-32dd7ab8.westus2.azurecontainerapps.io/ws/{USER_ID}"
+    # Azure App Service Web App (dual-stack: IPv4 + IPv6). Container App URL is retired.
+    f"wss://websocket-ai-pin-fbbrhfawfkb7ecf3.westus2-01.azurewebsites.net/ws/{USER_ID}"
+    # f"ws://localhost:8000/ws/{USER_ID}"  # local dev
 )
 
 def build_pending_message_init():

--- a/test/app/test_task_reminder.py
+++ b/test/app/test_task_reminder.py
@@ -24,8 +24,9 @@ load_dotenv()
 USER_ID = "2ba330c0-a999-46f8-ba2c-855880bdcf5b"
 TASK_ID = "ada542ad-dd67-44ef-a859-90ae03a017f4"
 WS_URI = (
-    f"ws://localhost:8000/ws/{USER_ID}"
-    #f"wss://websocket-ai-pin.bluesmoke-32dd7ab8.westus2.azurecontainerapps.io/ws/{USER_ID}"
+    # Azure App Service Web App (dual-stack: IPv4 + IPv6). Container App URL is retired.
+    f"wss://websocket-ai-pin-fbbrhfawfkb7ecf3.westus2-01.azurewebsites.net/ws/{USER_ID}"
+    # f"ws://localhost:8000/ws/{USER_ID}"  # local dev
 )
 
 

--- a/test/app/test_ws.py
+++ b/test/app/test_ws.py
@@ -88,8 +88,9 @@ class AudioManager:
 async def test_ws():
     user_id = "2ba330c0-a999-46f8-ba2c-855880bdcf5b"
 
-    uri = f"ws://localhost:8000/ws/{user_id}"
-    #uri = f"wss://websocket-ai-pin.bluesmoke-32dd7ab8.westus2.azurecontainerapps.io/ws/{user_id}"
+    # Azure App Service Web App (dual-stack: IPv4 + IPv6). Container App URL is retired.
+    uri = f"wss://websocket-ai-pin-fbbrhfawfkb7ecf3.westus2-01.azurewebsites.net/ws/{user_id}"
+    # uri = f"ws://localhost:8000/ws/{user_id}"  # local dev
     audio_mgr = AudioManager()
     
     try:


### PR DESCRIPTION
The Container App URL (`websocket-ai-pin.bluesmoke-*.azurecontainerapps.io`) is IPv4-only, so IPv6-only clients (e.g. ESP32 on Tello cellular) can't reach it. The App Service Web App is now configured with ipMode=IPv4AndIPv6 and an upgraded B1 plan that supports WebSockets, so the test clients should target that URL instead.

Deleted container as well.