### PR TITLE
Switch TTS to Piper; slim and harden Azure deploy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Shell scripts must keep LF endings on Windows too; bash heredocs (e.g. the
+# Python bundler inside azure-deploy.sh) break on CRLF because the trailing
+# `\r` makes the close-delimiter (PYEOF) not match.
+*.sh text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,9 @@ ENV/
 # Offline Vosk models (large downloads)
 vosk-model-*/
 
+# Piper TTS voice files (large downloads, fetched via README setup)
+piper_voices/
+
 # Claude Code local state (worktrees, settings)
 .claude/
 
@@ -76,3 +79,8 @@ htmlcov/
 mobile_app/android/app/google-services.json
 mobile_app/ios/Runner/GoogleService-Info.plist
 vertex_ai_service_account.json
+
+# Azure deploy artifacts
+deploy-*.zip
+data-bundle.zip
+creds.tmp.json

--- a/README.md
+++ b/README.md
@@ -2,27 +2,54 @@
 
 ## Initial Setup
 Clone the repo to whatever IDE you choose. Cursor AI is suggested.
-Create a top level .env file. The contents can be copy pasted from the internal doc (ask Rishi)
+Create a top level ```.env``` file. Contents can be copy-pasted from the internal doc (ask Rishi).
 
-## Create Virtual Environments
-All folders (features for lack of a better term) in the root repo should have their own venv.
-Ideally, all development is done in the venv and scoped into the particular feature that is being worked on.
+## Local Setup
 
-```python -m venv .venv``` if python is not installed, can use py (windows only)
+This project needs a Python venv plus three binary assets that are **gitignored** (Vosk STT model, Piper TTS voice, Opus native lib on Windows). Pip alone won't get you a working stack — do all five steps below.
 
-Start up the venv with ```. \.venv\Scripts\Activate.ps1```
-Or ```.\.venv\Scripts\activate.bat``` for Bash
+### 1. Python venv + deps
 
-If this is first time using the venv run:
-```pip install -r requirements.txt``` for python reqs.
+Each top-level "feature" folder has its own venv. Set up both the **root** venv and the **test** venv (```test/.venv```).
 
-Deactivate with...```deactivate```
+```powershell
+# Root
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+pip install -r requirements.txt
 
-Remember to set a venv in both the test folder and the root folder. Additionally a .env file
+# Test
+python -m venv test\.venv
+.\test\.venv\Scripts\Activate.ps1
+pip install -r test\requirements.txt
+deactivate
+```
 
-### Windows: Opus native library (for `opuslib` / realtime audio)
+Bash equivalent: ```. .venv/Scripts/activate``` (Git Bash on Windows) or ```source .venv/bin/activate``` (macOS/Linux).
 
-The `opuslib` package is only a Python binding. It loads the **native Opus DLL** (`opus.dll`). The `pip install` step installs `opuslib` but **does not** install that DLL.
+### 2. Vosk STT model (~68 MB, gitignored)
+
+```bash
+curl -L -o vosk-model.zip https://alphacephei.com/vosk/models/vosk-model-small-en-us-0.15.zip
+python -c "import zipfile; zipfile.ZipFile('vosk-model.zip').extractall('.')"
+rm vosk-model.zip
+```
+
+Sanity check: ```vosk-model-small-en-us-0.15/am/final.mdl``` must exist.
+
+### 3. Piper TTS voice (~60 MB, gitignored)
+
+Cross-platform neural TTS. Same ```.onnx``` voice file is used by the local server **and** the deployed server, so both sound identical.
+
+```bash
+mkdir -p piper_voices
+curl -L -o piper_voices/en_US-amy-medium.onnx       https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US/amy/medium/en_US-amy-medium.onnx
+curl -L -o piper_voices/en_US-amy-medium.onnx.json  https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US/amy/medium/en_US-amy-medium.onnx.json
+```
+
+### 4. Windows: install Opus native library
+
+```opuslib``` is a Python binding that loads the native ```opus.dll```. Pip does not install the DLL.
 
 Root venv:
 
@@ -30,13 +57,19 @@ Root venv:
 .\.venv\Scripts\python.exe scripts\install_opus_windows.py
 ```
 
-Separate **test** venv (only if you use `test\.venv`):
+Test venv (only if you have ```test\.venv```):
 
 ```powershell
 .\test\.venv\Scripts\python.exe scripts\install_opus_windows.py
 ```
 
-## Agent Developmet
+macOS/Linux: install via your package manager (```brew install opus``` / ```apt-get install libopus0```). No extra script needed.
+
+### 5. ```.env``` at repo root
+
+Pulled from the internal doc — ask Rishi. Contains ```AZURE_OPENAI_*```, ```DB_*```, ```GOOGLE_API_KEY```, ```AZURE_SERVICEBUS_CONNECTION_STRING```, etc.
+
+## Agent Development
 The Agent logic lives in the app dir. *This should eventually be renamed*
 
 To run a local websocket server, run ```python app/main.py```
@@ -50,10 +83,81 @@ Default brings up main, the mic client, and the echo relay (each in its own cons
 To run manually instead: ```python app/main.py```, then ```python test/app/developer/test_developer_ws.py```, then (from `app/`) ```python developer_ws/testing/echo_server.py``` (append ```--ping <user_id>``` for the auto-call variant).
 See ```app/developer_ws/DESIGN.md``` and ```BRIDGE_PROTOCOL.md``` for architecture and wire protocol.
 
-Instructions for deploying the app to Azure (App Service zip deploy — no Docker required):
-Prereqs: Azure CLI installed and ```az login``` completed, ```zip``` on PATH, the Vosk model unpacked at repo root as ```vosk-model-small-en-us-0.15/```, and a ```.env``` populated with the secrets the script pushes as App Settings.
-Mac: Run ```bash azure-deploy.sh``` from the repo root.
-Windows: Open Git Bash and run ```bash azure-deploy.sh``` from the repo root.
+## Deploy to Azure App Service
+
+Zip deploy, no Docker. Done by ```azure-deploy.sh```. Target: ```ai-pin``` resource group, ```websocket-ai-pin``` Linux App Service (Python 3.12, B1).
+
+### Prereqs
+
+- Azure CLI installed and ```az login``` complete (refresh token expires after 90d — re-login if you get ```AADSTS700082```).
+- Python 3.12 venv active. Script invokes ```$PYTHON_BIN``` to build the zip via ```zipfile``` stdlib.
+- ```.env``` populated. ```azure-deploy.sh``` reads ```.env``` and pushes the values as App Settings.
+- Local Vosk model + Piper voice exist (steps 2–3 above). Preflight checks for ```vosk-model-small-en-us-0.15/am/final.mdl``` and ```piper_voices/en_US-amy-medium.onnx```.
+- **Windows**: run via **Git Bash**, not WSL stub. PowerShell ```bash azure-deploy.sh``` defaults to WSL on Windows — use ```& "C:\Program Files\Git\bin\bash.exe" azure-deploy.sh``` instead, or open Git Bash directly.
+
+### One-time bootstrap: upload heavy assets to ```/home/data/```
+
+Vosk model + Piper voice live on App Service's persistent ```/home``` volume — not in every deploy zip. Upload them **once** so future deploys ship just app code (~MB, not ~100 MB):
+
+```bash
+# Build a bundle of both data dirs
+python -c "
+import zipfile, os
+EXCLUDE = {'__pycache__', '.pytest_cache'}
+def walk(zf, root):
+    for r, dirs, files in os.walk(root):
+        dirs[:] = [d for d in dirs if d not in EXCLUDE]
+        for f in files:
+            if f.endswith('.pyc'): continue
+            p = os.path.join(r, f)
+            zf.write(p, arcname=p.replace(os.sep, '/'))
+with zipfile.ZipFile('data-bundle.zip', 'w', zipfile.ZIP_DEFLATED) as zf:
+    walk(zf, 'vosk-model-small-en-us-0.15')
+    walk(zf, 'piper_voices')
+"
+
+# Upload + extract to /home/data via Kudu (uses ARM bearer auth — no publishing creds)
+TOKEN=$(az account get-access-token --resource https://management.azure.com/ --query accessToken -o tsv)
+curl -X PUT -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/zip" \
+     --data-binary "@data-bundle.zip" \
+     "https://websocket-ai-pin-fbbrhfawfkb7ecf3.scm.westus2-01.azurewebsites.net/api/zip/data/"
+rm data-bundle.zip
+```
+
+This step only repeats when the Vosk model or Piper voice file changes.
+
+### Deploy
+
+```bash
+# Git Bash (Windows) or any bash (macOS/Linux)
+bash azure-deploy.sh
+```
+
+What it does:
+
+1. Pushes app settings from ```.env``` (```VOSK_MODEL_PATH=/home/data/...```, ```PIPER_MODEL_PATH=/home/data/...```, secrets).
+2. Sets the startup file: ```bash -c "apt-get update -qq && apt-get install -y -qq libopus0 && cd app && python -m uvicorn main:app --host 0.0.0.0 --port 8000 --ws websockets"``` — installs libopus on every cold start.
+3. Builds a slim zip (app code + ```requirements.txt```, no data assets).
+4. Pushes the zip via ```az webapp deploy```. Oryx repacks into ```output.tar.zst``` and extracts at runtime.
+5. Polls deployment status for up to 15 min, then prints URLs.
+
+### URLs
+
+- App:    ```https://websocket-ai-pin-fbbrhfawfkb7ecf3.westus2-01.azurewebsites.net```
+- WS:     ```wss://websocket-ai-pin-fbbrhfawfkb7ecf3.westus2-01.azurewebsites.net/ws```
+- Health: ```/healthz```
+
+### Viewing logs
+
+```bash
+# Live tail (Ctrl+C to stop)
+az webapp log tail --name websocket-ai-pin --resource-group ai-pin
+
+# Or via Kudu in a browser
+# https://websocket-ai-pin-fbbrhfawfkb7ecf3.scm.westus2-01.azurewebsites.net/newui/fileManager → /home/LogFiles/
+```
+
+If logging stops working: ```az webapp log config --name websocket-ai-pin --resource-group ai-pin --application-logging filesystem --level information --docker-container-logging filesystem```.
 
 ## Git Rules
 Create a new branch: ```git checkout -b <name>```

--- a/README.md
+++ b/README.md
@@ -50,14 +50,10 @@ Default brings up main, the mic client, and the echo relay (each in its own cons
 To run manually instead: ```python app/main.py```, then ```python test/app/developer/test_developer_ws.py```, then (from `app/`) ```python developer_ws/testing/echo_server.py``` (append ```--ping <user_id>``` for the auto-call variant).
 See ```app/developer_ws/DESIGN.md``` and ```BRIDGE_PROTOCOL.md``` for architecture and wire protocol.
 
-Instructions for deploying the app to Azure:
-Mac Instructions:
-Run ```bash azure-deploy-simple.sh ``` to deploy container
-
-Windows Instructions:
-Ensure you have git bash. All instructions will be assuming you are in bash.
-Ensure you have docker desktop running. Try ```docker ps``` and see that it prints a table (empty is fine)
-Run ```bash azure-deploy-simple.sh``` to deploy container
+Instructions for deploying the app to Azure (App Service zip deploy — no Docker required):
+Prereqs: Azure CLI installed and ```az login``` completed, ```zip``` on PATH, the Vosk model unpacked at repo root as ```vosk-model-small-en-us-0.15/```, and a ```.env``` populated with the secrets the script pushes as App Settings.
+Mac: Run ```bash azure-deploy.sh``` from the repo root.
+Windows: Open Git Bash and run ```bash azure-deploy.sh``` from the repo root.
 
 ## Git Rules
 Create a new branch: ```git checkout -b <name>```

--- a/app/developer_ws/__init__.py
+++ b/app/developer_ws/__init__.py
@@ -8,5 +8,11 @@ WebSocket service instead of going through STT/LLM/TTS. See DESIGN.md and BRIDGE
 from .audio_io import AudioIO
 from .endpoint import developer_websocket_endpoint
 from .stt import preload_vosk_model
+from .tts import preload_piper_voice
 
-__all__ = ["AudioIO", "developer_websocket_endpoint", "preload_vosk_model"]
+__all__ = [
+    "AudioIO",
+    "developer_websocket_endpoint",
+    "preload_vosk_model",
+    "preload_piper_voice",
+]

--- a/app/developer_ws/tts.py
+++ b/app/developer_ws/tts.py
@@ -1,69 +1,111 @@
-"""Offline (pyttsx3) text-to-speech.
+"""Piper text-to-speech.
 
 `synthesize_speech_pcm24(text)` returns int16 mono PCM at the downlink sample rate
-(24 kHz), resampling from whatever the OS voice produces. Returned bytes are queued
-on `AudioIO` for Opus encoding and downlink delivery.
+(24 kHz), resampling from Piper's native rate. Returned bytes are queued on
+`AudioIO` for Opus encoding and downlink delivery.
+
+Piper is cross-platform (Windows / Linux / macOS) and uses the same `.onnx` voice
+file everywhere, so local and deployed runs sound identical.
+
+Voice path resolution:
+  1. ``PIPER_MODEL_PATH`` env var (relative paths resolve from CWD).
+  2. Default: ``piper_voices/en_US-amy-medium.onnx`` relative to repo root.
 """
 
 from __future__ import annotations
 
 import asyncio
 import audioop
+import io
 import logging
 import os
-import tempfile
+import threading
 import wave
 
 from audio_codec import DOWNLINK_SAMPLE_RATE
 
 log = logging.getLogger("developer_ws")
 
+_DEFAULT_MODEL = "piper_voices/en_US-amy-medium.onnx"
+
+_voice = None
+_voice_path: str | None = None
+_load_lock = threading.Lock()
+
+
+def _resolve_model_path() -> str | None:
+    raw = os.environ.get("PIPER_MODEL_PATH", "").strip() or _DEFAULT_MODEL
+    for candidate in (raw, os.path.join("..", raw)):
+        if os.path.isfile(candidate):
+            return candidate
+    return None
+
+
+def _load_voice():
+    """Load (or return cached) Piper voice. Returns None if model file is missing."""
+    global _voice, _voice_path
+    path = _resolve_model_path()
+    if not path:
+        return None
+    with _load_lock:
+        if _voice is not None and _voice_path == path:
+            return _voice
+        try:
+            from piper import PiperVoice
+        except ImportError:
+            log.warning("piper-tts not installed. pip install piper-tts")
+            return None
+        try:
+            _voice = PiperVoice.load(path)
+            _voice_path = path
+            log.info("piper voice loaded: %s", path)
+            return _voice
+        except Exception as e:
+            log.warning("piper voice load failed (%s): %s", path, e)
+            return None
+
 
 def _synthesize_sync(text: str) -> bytes:
-    """Render text via pyttsx3, return mono int16 PCM at DOWNLINK_SAMPLE_RATE."""
+    """Render text via Piper, return mono int16 PCM at DOWNLINK_SAMPLE_RATE."""
     t = text.strip()
     if not t:
         return b""
-    try:
-        import pyttsx3
-    except ImportError:
-        log.warning("pyttsx3 not installed. pip install pyttsx3")
+    voice = _load_voice()
+    if voice is None:
+        log.warning("piper voice unavailable; TTS disabled.")
         return b""
-
-    fd, wav_path = tempfile.mkstemp(suffix=".wav")
-    os.close(fd)
     try:
-        engine = pyttsx3.init()
-        engine.save_to_file(t, wav_path)
-        engine.runAndWait()
-
-        with wave.open(wav_path, "rb") as wf:
+        # Piper writes a WAV header + PCM into the wave.Wave_write. Sample rate
+        # comes from the voice's config; we resample to DOWNLINK_SAMPLE_RATE.
+        buf = io.BytesIO()
+        with wave.open(buf, "wb") as wav:
+            voice.synthesize_wav(t, wav)
+        buf.seek(0)
+        with wave.open(buf, "rb") as wf:
             channels = wf.getnchannels()
             rate = wf.getframerate()
             sample_width = wf.getsampwidth()
             pcm = wf.readframes(wf.getnframes())
-
-        if sample_width != 2:
-            log.warning("pyttsx3 produced %d-bit audio; expected 16-bit WAV", sample_width * 8)
-            return b""
-        if channels == 2:
-            pcm = audioop.tomono(pcm, 2, 0.5, 0.5)
-        elif channels != 1:
-            return b""
-
-        if rate == DOWNLINK_SAMPLE_RATE:
-            return pcm
-        # Resample to the wire rate so downlink can be Opus-encoded directly.
-        resampled, _ = audioop.ratecv(pcm, 2, 1, rate, DOWNLINK_SAMPLE_RATE, None)
-        return resampled
     except Exception as e:
-        log.warning("pyttsx3 TTS failed: %s", e)
+        log.warning("piper synthesize failed: %s", e)
         return b""
-    finally:
-        try:
-            os.remove(wav_path)
-        except OSError:
-            pass
+
+    if sample_width != 2:
+        log.warning("piper produced %d-bit audio; expected 16-bit", sample_width * 8)
+        return b""
+    if channels == 2:
+        pcm = audioop.tomono(pcm, 2, 0.5, 0.5)
+    elif channels != 1:
+        return b""
+    if rate == DOWNLINK_SAMPLE_RATE:
+        return pcm
+    resampled, _ = audioop.ratecv(pcm, 2, 1, rate, DOWNLINK_SAMPLE_RATE, None)
+    return resampled
+
+
+async def preload_piper_voice() -> None:
+    """Warm the Piper voice cache so the first TTS call doesn't stall (~1-2s)."""
+    await asyncio.to_thread(_load_voice)
 
 
 async def synthesize_speech_pcm24(text: str) -> bytes:
@@ -71,6 +113,6 @@ async def synthesize_speech_pcm24(text: str) -> bytes:
 
     Called by: `pipeline._speak` after Gemini returns plain text, after a tool ack,
     after a service-ping announcement, and on bridge remote-close notification.
-    Offloaded to a worker thread because pyttsx3 is blocking.
+    Offloaded to a worker thread because Piper inference is CPU-bound.
     """
     return await asyncio.to_thread(_synthesize_sync, text)

--- a/app/main.py
+++ b/app/main.py
@@ -14,7 +14,11 @@ load_dotenv()
 from routes.task_routes import router
 from routes.messaging_routes import router as messaging_router
 from websocket_handler import websocket_endpoint
-from developer_ws import developer_websocket_endpoint, preload_vosk_model
+from developer_ws import (
+    developer_websocket_endpoint,
+    preload_piper_voice,
+    preload_vosk_model,
+)
 from developer_ws import registry as developer_registry
 
 
@@ -26,6 +30,11 @@ async def lifespan(app: FastAPI):
         print("[main] vosk model preloaded")
     except Exception as e:
         print(f"[main] vosk preload failed: {e}")
+    try:
+        await preload_piper_voice()
+        print("[main] piper voice preloaded")
+    except Exception as e:
+        print(f"[main] piper preload failed: {e}")
     yield
 
 

--- a/azure-deploy.sh
+++ b/azure-deploy.sh
@@ -14,13 +14,20 @@ PLAN_NAME="ASP-aipin-9950"
 PYTHON_VERSION="3.12"
 SKU="B1"
 
-# Vosk STT model: gitignored, must be present locally so it can ship in the zip.
-# The model lands at /home/site/wwwroot/<dir> on App Service Linux.
+# Vosk STT model + Piper TTS voice live on the App Service's persistent
+# /home volume (`/home/data/...`). They are uploaded once via Kudu's
+# /api/zip/data/ endpoint (~130 MB total) and reused across deploys, so we
+# don't reship them in every zip. Local preflight still checks they exist on
+# disk in case someone needs to re-upload.
 VOSK_MODEL_DIR="vosk-model-small-en-us-0.15"
-REMOTE_VOSK_PATH="/home/site/wwwroot/${VOSK_MODEL_DIR}"
+REMOTE_VOSK_PATH="/home/data/${VOSK_MODEL_DIR}"
+
+PIPER_VOICES_DIR="piper_voices"
+PIPER_VOICE_FILE="en_US-amy-medium.onnx"
+REMOTE_PIPER_MODEL_PATH="/home/data/${PIPER_VOICES_DIR}/${PIPER_VOICE_FILE}"
 
 ZIP_FILE="deploy-$(date +%Y%m%d-%H%M%S).zip"
-STARTUP_CMD='bash -c "cd app && python -m uvicorn main:app --host 0.0.0.0 --port 8000 --ws websockets --ws-ping-interval 0 --ws-ping-timeout 0"'
+STARTUP_CMD='bash -c "apt-get update -qq && apt-get install -y -qq libopus0 && cd app && python -m uvicorn main:app --host 0.0.0.0 --port 8000 --ws websockets"'
 
 echo "Starting Azure App Service deployment..."
 
@@ -53,7 +60,7 @@ for _cand in \
     "python3" \
     "python"; do
     [ -z "$_cand" ] && continue
-    if "$_cand" --version 2>&1 | grep -q "^Python "; then
+    if "$_cand" --version 2>&1 | grep -qE "^Python [0-9]"; then
         PYTHON_BIN="$_cand"
         break
     fi
@@ -64,9 +71,14 @@ if [ -z "$PYTHON_BIN" ]; then
     exit 1
 fi
 echo "Using Python: $PYTHON_BIN"
-if [ ! -d "$VOSK_MODEL_DIR" ]; then
-    echo "Vosk model dir missing: $VOSK_MODEL_DIR"
+if [ ! -d "$VOSK_MODEL_DIR" ] || [ ! -f "$VOSK_MODEL_DIR/am/final.mdl" ]; then
+    echo "Vosk model dir missing or empty: $VOSK_MODEL_DIR"
     echo "Download it (e.g. https://alphacephei.com/vosk/models) and unpack it at the repo root."
+    exit 1
+fi
+if [ ! -f "${PIPER_VOICES_DIR}/${PIPER_VOICE_FILE}" ] || [ ! -f "${PIPER_VOICES_DIR}/${PIPER_VOICE_FILE}.json" ]; then
+    echo "Piper voice files missing in ${PIPER_VOICES_DIR}/"
+    echo "Download from https://huggingface.co/rhasspy/piper-voices (e.g. en_US-amy-medium.onnx + .onnx.json)."
     exit 1
 fi
 
@@ -115,9 +127,11 @@ az webapp update \
     --https-only true \
     --output none
 
-# App settings: env vars + build-on-deploy so requirements.txt installs
+# App settings: env vars + build-on-deploy so requirements.txt installs.
+# MSYS_NO_PATHCONV=1: Git Bash on Windows otherwise rewrites /home/... args
+# to C:/Program Files/Git/home/... when passed to native az.exe.
 echo "Setting app settings (env vars + build flags)..."
-az webapp config appsettings set \
+MSYS_NO_PATHCONV=1 az webapp config appsettings set \
     --name "$APP_NAME" \
     --resource-group "$RESOURCE_GROUP" \
     --settings \
@@ -133,6 +147,7 @@ az webapp config appsettings set \
         GOOGLE_API_KEY="${GOOGLE_API_KEY}" \
         AZURE_SERVICEBUS_CONNECTION_STRING="${AZURE_SERVICEBUS_CONNECTION_STRING}" \
         VOSK_MODEL_PATH="${REMOTE_VOSK_PATH}" \
+        PIPER_MODEL_PATH="${REMOTE_PIPER_MODEL_PATH}" \
         ApplicationInsightsAgent_EXTENSION_VERSION="disabled" \
         XDT_MicrosoftApplicationInsights_Mode="disabled" \
         APPLICATIONINSIGHTS_CONNECTION_STRING="" \
@@ -141,10 +156,10 @@ az webapp config appsettings set \
 
 # Build deployment zip via Python stdlib (portable; no `zip` dependency).
 echo "Building deployment zip: $ZIP_FILE"
-"$PYTHON_BIN" - "$ZIP_FILE" "$VOSK_MODEL_DIR" <<'PYEOF'
+"$PYTHON_BIN" - "$ZIP_FILE" <<'PYEOF'
 import os, sys, zipfile
 
-zip_path, vosk_dir = sys.argv[1], sys.argv[2]
+zip_path = sys.argv[1]
 EXCLUDE_DIRS = {"__pycache__", ".pytest_cache"}
 
 def walk_into(zf, root):
@@ -156,9 +171,10 @@ def walk_into(zf, root):
             p = os.path.join(r, f)
             zf.write(p, arcname=p.replace(os.sep, "/"))
 
+# Vosk model + Piper voice live on /home/data on the App Service (uploaded
+# once via Kudu's /api/zip/data/), so they are *not* shipped in every deploy.
 with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
     walk_into(zf, "app")
-    walk_into(zf, vosk_dir)
     zf.write("requirements.txt")
 PYEOF
 

--- a/azure-deploy.sh
+++ b/azure-deploy.sh
@@ -14,6 +14,11 @@ PLAN_NAME="ASP-aipin-9950"
 PYTHON_VERSION="3.12"
 SKU="B1"
 
+# Vosk STT model: gitignored, must be present locally so it can ship in the zip.
+# The model lands at /home/site/wwwroot/<dir> on App Service Linux.
+VOSK_MODEL_DIR="vosk-model-small-en-us-0.15"
+REMOTE_VOSK_PATH="/home/site/wwwroot/${VOSK_MODEL_DIR}"
+
 ZIP_FILE="deploy-$(date +%Y%m%d-%H%M%S).zip"
 STARTUP_CMD='bash -c "cd app && python -m uvicorn main:app --host 0.0.0.0 --port 8000 --ws websockets --ws-ping-interval 0 --ws-ping-timeout 0"'
 
@@ -36,8 +41,32 @@ if ! az account show &> /dev/null; then
     echo "Not logged in. Run 'az login' first."
     exit 1
 fi
-if ! command -v zip &> /dev/null; then
-    echo "zip command missing. Install first."
+# Find a real Python interpreter. On Windows, `python` on PATH is often the
+# Microsoft Store stub — it exits with "Python was not found..." instead of
+# running. Verify each candidate by actually invoking --version and matching
+# its output, so the stub is skipped.
+PYTHON_BIN=""
+for _cand in \
+    "$PYTHON" \
+    "$VIRTUAL_ENV/Scripts/python.exe" \
+    "$VIRTUAL_ENV/bin/python" \
+    "python3" \
+    "python"; do
+    [ -z "$_cand" ] && continue
+    if "$_cand" --version 2>&1 | grep -q "^Python "; then
+        PYTHON_BIN="$_cand"
+        break
+    fi
+done
+if [ -z "$PYTHON_BIN" ]; then
+    echo "Could not find a working Python interpreter."
+    echo "Activate your venv (e.g. 'source .venv/Scripts/activate') or set PYTHON=/path/to/python."
+    exit 1
+fi
+echo "Using Python: $PYTHON_BIN"
+if [ ! -d "$VOSK_MODEL_DIR" ]; then
+    echo "Vosk model dir missing: $VOSK_MODEL_DIR"
+    echo "Download it (e.g. https://alphacephei.com/vosk/models) and unpack it at the repo root."
     exit 1
 fi
 
@@ -103,23 +132,63 @@ az webapp config appsettings set \
         DB_PASSWORD="${DB_PASSWORD}" \
         GOOGLE_API_KEY="${GOOGLE_API_KEY}" \
         AZURE_SERVICEBUS_CONNECTION_STRING="${AZURE_SERVICEBUS_CONNECTION_STRING}" \
+        VOSK_MODEL_PATH="${REMOTE_VOSK_PATH}" \
+        ApplicationInsightsAgent_EXTENSION_VERSION="disabled" \
+        XDT_MicrosoftApplicationInsights_Mode="disabled" \
+        APPLICATIONINSIGHTS_CONNECTION_STRING="" \
+        OTEL_SDK_DISABLED="true" \
     --output none
 
-# Build deployment zip (only what runtime needs)
+# Build deployment zip via Python stdlib (portable; no `zip` dependency).
 echo "Building deployment zip: $ZIP_FILE"
-zip -rq "$ZIP_FILE" \
-    app \
-    requirements.txt \
-    -x "*/__pycache__/*" "*.pyc" "*/.pytest_cache/*"
+"$PYTHON_BIN" - "$ZIP_FILE" "$VOSK_MODEL_DIR" <<'PYEOF'
+import os, sys, zipfile
 
-# Push zip to Kudu
+zip_path, vosk_dir = sys.argv[1], sys.argv[2]
+EXCLUDE_DIRS = {"__pycache__", ".pytest_cache"}
+
+def walk_into(zf, root):
+    for r, dirs, files in os.walk(root):
+        dirs[:] = [d for d in dirs if d not in EXCLUDE_DIRS]
+        for f in files:
+            if f.endswith(".pyc"):
+                continue
+            p = os.path.join(r, f)
+            zf.write(p, arcname=p.replace(os.sep, "/"))
+
+with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+    walk_into(zf, "app")
+    walk_into(zf, vosk_dir)
+    zf.write("requirements.txt")
+PYEOF
+
+# Push zip to Kudu.
+# --track-status false avoids the CLI returning 504 while Azure is still
+# building. Deployment continues server-side; status is polled separately below.
 echo "Deploying zip to App Service..."
 az webapp deploy \
     --name "$APP_NAME" \
     --resource-group "$RESOURCE_GROUP" \
     --src-path "$ZIP_FILE" \
     --type zip \
+    --track-status false \
     --output none
+
+# Wait for the build/deploy to finish on Azure, then report final status.
+echo "Waiting for deployment to complete on Azure..."
+DEPLOY_DEADLINE=$(( $(date +%s) + 900 ))  # 15 minutes
+while [ "$(date +%s)" -lt "$DEPLOY_DEADLINE" ]; do
+    STATUS=$(az webapp log deployment list \
+        --name "$APP_NAME" \
+        --resource-group "$RESOURCE_GROUP" \
+        --query "[0].status" -o tsv 2>/dev/null || echo "?")
+    case "$STATUS" in
+        4) echo "  status=Success"; break ;;
+        3) echo "  status=Failed — check the log_url from 'az webapp log deployment list'"; break ;;
+        *) echo "  status=$STATUS (pending/building/deploying); sleeping 15s..." ;;
+    esac
+    sleep 15
+done
 
 rm -f "$ZIP_FILE"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ google-genai>=1.70.0
 
 # Developer WebSocket offline STT/TTS (optional if you only use /ws/)
 vosk
-pyttsx3
+piper-tts
 
 # Azure (device SDK has wheels; service SDK optional, see below)
 azure-servicebus

--- a/test/app/developer/test_developer_ws.py
+++ b/test/app/developer/test_developer_ws.py
@@ -128,7 +128,8 @@ async def run_developer_ws_session() -> None:
         "DEVELOPER_WS_USER_ID", "2ba330c0-a999-46f8-ba2c-855880bdcf5b"
     )
     base = os.environ.get("DEVELOPER_WS_BASE", "ws://localhost:8000").rstrip("/")
-    uri = f"{base}/ws/developer/{user_id}"
+    #uri = f"{base}/ws/developer/{user_id}"
+    uri = f"wss://websocket-ai-pin-fbbrhfawfkb7ecf3.westus2-01.azurewebsites.net/ws/developer/{user_id}"
     # Example remote: wss://...azurewebsites.net/ws/developer/{user_id}
 
     audio_mgr = AudioManager()

--- a/test/app/developer/test_developer_ws.py
+++ b/test/app/developer/test_developer_ws.py
@@ -128,7 +128,7 @@ async def run_developer_ws_session() -> None:
         "DEVELOPER_WS_USER_ID", "2ba330c0-a999-46f8-ba2c-855880bdcf5b"
     )
     base = os.environ.get("DEVELOPER_WS_BASE", "ws://localhost:8000").rstrip("/")
-    #uri = f"{base}/ws/developer/{user_id}"
+    # uri = f"{base}/ws/developer/{user_id}"
     uri = f"wss://websocket-ai-pin-fbbrhfawfkb7ecf3.westus2-01.azurewebsites.net/ws/developer/{user_id}"
     # Example remote: wss://...azurewebsites.net/ws/developer/{user_id}
 


### PR DESCRIPTION
## Summary

- Replace pyttsx3 / espeak-ng with Piper TTS. Same `en_US-amy-medium` voice file runs on Windows (local) and Linux (App Service), so the local server and deployed server now sound identical.
- Move Vosk model + Piper voice off every deploy zip onto App Service's persistent `/home/data` volume; future deploys ship ~MB instead of ~100 MB.
- Fix several real `azure-deploy.sh` bugs (Python detection, MSYS path mangling, broken WS keepalive flags, missing libopus on container).
- Rewrite the README's Local Setup + Deploy sections with explicit step-by-step instructions.

## What changed and why

### TTS — Piper
- `app/developer_ws/tts.py` rewritten to use `piper-tts`. Reads `PIPER_MODEL_PATH` (falls back to `piper_voices/en_US-amy-medium.onnx`), synthesises via `voice.synthesize_wav(...)`, resamples Piper's 22.05 kHz output to the 24 kHz downlink rate.
- `app/main.py` + `app/developer_ws/__init__.py` preload the Piper voice during FastAPI startup (mirrors the Vosk preload) so the first TTS call doesn't pay the ~1–2 s cold load.
- `requirements.txt`: `pyttsx3` → `piper-tts`. pyttsx3's espeak driver crashes with `ReferenceError: weakly-referenced object no longer exists` under our async/thread pattern; Piper is cross-platform and avoids that entire failure mode.

### Slim Azure deploy
- Vosk model (~68 MB) and Piper voice (~60 MB) now live at `/home/data/vosk-model-small-en-us-0.15/` and `/home/data/piper_voices/en_US-amy-medium.onnx`. README documents the one-time bootstrap via Kudu's `/api/zip/data/` endpoint.
- `azure-deploy.sh` no longer walks those directories into the zip. App settings (`VOSK_MODEL_PATH`, `PIPER_MODEL_PATH`) point at absolute `/home/data/...` paths.

### Deploy-script fixes
- Tightened the Python detection regex from `^Python ` to `^Python [0-9]` — the Windows Store Python stub's `Python was not found...` message used to pass the original check and then fail at runtime.
- Tightened the Vosk preflight to require `am/final.mdl`, not just the directory (the local model dir had been empty without anyone noticing).
- Wrapped `az webapp config appsettings set` in `MSYS_NO_PATHCONV=1`. Git Bash on Windows otherwise rewrites `/home/site/wwwroot/...` arguments to `C:/Program Files/Git/home/site/wwwroot/...` when passing them to native `az.exe`.
- Removed `--ws-ping-interval 0 --ws-ping-timeout 0` from the startup command. In the `websockets` library, `0` means "ping every 0 s, timeout in 0 s" — not "disabled" — so every connection was closing immediately with `1011 keepalive ping timeout`.
- Startup now `apt-get install -y -qq libopus0` before launching uvicorn. Without it, the server logged `Opus unavailable, falling back to raw PCM` and downlink frames went uncompressed.

### Misc
- `.gitattributes` forces `*.sh` to LF. The Python heredoc inside `azure-deploy.sh` breaks on Windows checkouts because `PYEOF\r` doesn't match the closing `PYEOF` delimiter.
- `.gitignore` adds `piper_voices/`, `deploy-*.zip`, `data-bundle.zip`, `creds.tmp.json`.
- README's Local Setup section now spells out venv → Vosk download → Piper download → `opus.dll` (Windows) → `.env`. Deploy section adds prereqs, the one-time `/home/data` bootstrap, and log-viewing commands.

## Test plan

- [x] Probed deployed server with synthetic audio: STT → Gemini → Piper TTS → Opus downlink, received 5 audio frames per turn.
- [x] `[main] piper voice preloaded` confirmed in App Service logs (loads from `/home/data/piper_voices/en_US-amy-medium.onnx`).
- [x] `/healthz` returns 200 after redeploy.
- [ ] End-to-end mic test from `test_developer_ws.py` (requires reviewer to install `opus.dll` via `scripts/install_opus_windows.py` if not already done).

🤖 Generated with [Claude Code](https://claude.com/claude-code)