### PR TITLE
developer_ws: add service registry + register/unregister endpoints

### DIFF
--- a/app/developer_ws/__init__.py
+++ b/app/developer_ws/__init__.py
@@ -5,6 +5,7 @@ When Gemini calls `start_remote_audio_bridge`, frames are relayed verbatim to a 
 WebSocket service instead of going through STT/LLM/TTS. See DESIGN.md and BRIDGE_PROTOCOL.md.
 """
 
+from . import service_registry
 from .audio_io import AudioIO
 from .endpoint import developer_websocket_endpoint
 from .stt import preload_vosk_model
@@ -15,4 +16,5 @@ __all__ = [
     "developer_websocket_endpoint",
     "preload_vosk_model",
     "preload_piper_voice",
+    "service_registry",
 ]

--- a/app/developer_ws/pipeline.py
+++ b/app/developer_ws/pipeline.py
@@ -193,20 +193,30 @@ class SpeechPipeline:
             return
         await self._speak(ack)
 
-    async def on_service_ping(self, service_id: str = "") -> bool:
+    async def on_service_ping(
+        self, service_id: str = "", public_url: str | None = None,
+    ) -> bool:
         """Service-initiated call: announce to the user, then dial the bridge.
 
         Called by: `developer_ping` HTTP handler in `app/main.py` after
-        `registry.get(user_id)` returns this pipeline.
+        `registry.get(user_id)` returns this pipeline. `public_url` is the URL
+        the orchestrator just resolved out of `service_registry.get(service_id)`
+        — when provided, the bridge dials it instead of the legacy
+        `DEVELOPER_WS_REMOTE_BRIDGE_URL` env var. `public_url` may be None for
+        back-compat with callers that did not register a service_id, in which
+        case we fall back to the env-driven default.
         Calls: `_speak(announce)` → `bridge.start(...)` → either `_speak(fail)` or
         a scratchpad ack. Compares `service_id` from the ping body against
         `result.service_id` from the WS ack; logs a warning on mismatch.
         Takes `self._lock` so the announcement can't talk over an in-flight user turn.
         Returns True if the bridge is open (newly or already) when we exit.
         """
+        dial_url = public_url or REMOTE_BRIDGE_URL
         log.info(
-            "user_id=%s service ping received service_id=%s",
-            self._user_id, service_id or "unknown",
+            "user_id=%s service ping received service_id=%s dial_url=%s "
+            "(source=%s)",
+            self._user_id, service_id or "unknown", dial_url,
+            "registry" if public_url else "env-fallback",
         )
         if self._bridge.active:
             log.info("user_id=%s bridge already active; ignoring ping", self._user_id)
@@ -221,7 +231,7 @@ class SpeechPipeline:
             if not self._alive():
                 return False
             await self._speak(_SERVICE_PING_ANNOUNCE)
-            result = await self._bridge.start(REMOTE_BRIDGE_URL)
+            result = await self._bridge.start(dial_url)
             log.info(
                 "user_id=%s ping->bridge result ok=%s outcome=%s detail=%r service_id=%s",
                 self._user_id, result.ok, result.outcome, result.detail,

--- a/app/developer_ws/service_registry.py
+++ b/app/developer_ws/service_registry.py
@@ -1,0 +1,133 @@
+"""In-memory registry of developer services, keyed by service_id.
+
+Separate from `registry.py` (which tracks end-user pipelines by user_id). This
+registry stores the **outbound dial URL** a developer service currently lives
+at, so the orchestrator can route `request_orchestrator_call(user_id)` traffic
+to whatever transient `cloudflared` URL (or self-hosted equivalent) the service
+self-published on startup.
+
+Lifecycle:
+  - Service starts → POST /developer/register {service_id, public_url} →
+    `register(service_id, public_url)` stores the mapping.
+  - Service heartbeats (~every 5 min) → re-POST /developer/register with the
+    current URL → `register(...)` overwrites and bumps `last_seen`.
+  - Service shuts down → POST /developer/unregister {service_id} →
+    `unregister(service_id)` deletes the mapping.
+  - HTTP ping `/developer/ping/{user_id}` body carries `service_id` →
+    `get(service_id)` returns the current URL or None.
+
+No authentication. Last-write-wins. Intended for development and demo. A
+production deployment should layer auth + per-service-id ownership on top.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from threading import Lock
+from typing import Dict, List, Optional
+
+log = logging.getLogger("developer_ws")
+
+
+@dataclass
+class ServiceEntry:
+    """One row in the service registry."""
+    service_id: str
+    public_url: str
+    registered_at: float  # epoch seconds, first register call for this service_id
+    last_seen: float      # epoch seconds, most recent register/heartbeat
+    version: str = "1"
+
+
+_entries: Dict[str, ServiceEntry] = {}
+_lock = Lock()
+
+
+def register(service_id: str, public_url: str, version: str = "1") -> ServiceEntry:
+    """Called by the HTTP `/developer/register` route in `app/main.py`.
+
+    Idempotent: re-registering an existing service_id overwrites `public_url`
+    and bumps `last_seen` (this is how heartbeats keep the entry fresh).
+    Returns the stored entry so the caller can echo `registered_at` in the
+    response if it wants to.
+    """
+    now = time.time()
+    with _lock:
+        existing = _entries.get(service_id)
+        if existing is None:
+            entry = ServiceEntry(
+                service_id=service_id,
+                public_url=public_url,
+                registered_at=now,
+                last_seen=now,
+                version=version,
+            )
+            _entries[service_id] = entry
+            log.info(
+                "service registered service_id=%s public_url=%s (active=%d)",
+                service_id, public_url, len(_entries),
+            )
+            return entry
+        # Heartbeat / URL change path.
+        url_changed = existing.public_url != public_url
+        existing.public_url = public_url
+        existing.last_seen = now
+        existing.version = version
+        if url_changed:
+            log.info(
+                "service URL changed service_id=%s public_url=%s (active=%d)",
+                service_id, public_url, len(_entries),
+            )
+        else:
+            log.debug(
+                "service heartbeat service_id=%s (active=%d)",
+                service_id, len(_entries),
+            )
+        return existing
+
+
+def unregister(service_id: str) -> bool:
+    """Called by the HTTP `/developer/unregister` route in `app/main.py`.
+
+    Returns True if an entry was removed, False if no such service was
+    registered (idempotent — the route still returns 200 either way).
+    """
+    with _lock:
+        removed = _entries.pop(service_id, None)
+    if removed is None:
+        log.info("unregister called for unknown service_id=%s", service_id)
+        return False
+    log.info(
+        "service unregistered service_id=%s (active=%d)",
+        service_id, len(_entries),
+    )
+    return True
+
+
+def get(service_id: str) -> Optional[ServiceEntry]:
+    """Called by the HTTP `/developer/ping/{user_id}` route to resolve where to
+    dial. Returns None if the service is not currently registered (the route
+    then responds with `{"ok": false, "reason": "service not registered"}`).
+    """
+    with _lock:
+        return _entries.get(service_id)
+
+
+def get_url(service_id: str) -> Optional[str]:
+    """Convenience wrapper returning just the URL."""
+    entry = get(service_id)
+    return entry.public_url if entry is not None else None
+
+
+def list_all() -> List[ServiceEntry]:
+    """Snapshot of all registered services. Used by a debug endpoint."""
+    with _lock:
+        return list(_entries.values())
+
+
+def clear() -> None:
+    """Test hook — drops every registered service."""
+    with _lock:
+        _entries.clear()

--- a/app/main.py
+++ b/app/main.py
@@ -20,6 +20,7 @@ from developer_ws import (
     preload_vosk_model,
 )
 from developer_ws import registry as developer_registry
+from developer_ws import service_registry as developer_service_registry
 
 
 @asynccontextmanager
@@ -49,6 +50,100 @@ app.websocket("/ws/{user_id}")(websocket_endpoint)
 app.websocket("/ws/developer/{user_id}")(developer_websocket_endpoint)
 
 
+_ALLOWED_URL_SCHEMES = ("ws://", "wss://")
+
+
+def _validate_public_url(url: str) -> str | None:
+    """Return None if the URL is acceptable to register, otherwise a short reason."""
+    if not url:
+        return "public_url is required"
+    if not isinstance(url, str):
+        return "public_url must be a string"
+    if not url.startswith(_ALLOWED_URL_SCHEMES):
+        return f"public_url must start with one of {_ALLOWED_URL_SCHEMES}"
+    return None
+
+
+@app.post("/developer/register")
+async def developer_register(payload: dict | None = Body(default=None)):
+    """Developer service registers its current public dial URL.
+
+    Called by: a service implementing BUILD_SERVICE_PROMPT_V2 on startup (and
+    every ~5 min as a heartbeat). The dial URL is typically a fresh
+    `wss://<random>.trycloudflare.com/<path>` that changes on every restart, so
+    the service tells the orchestrator where to find it instead of hardcoding
+    one URL on either side.
+
+    Body: `{service_id, public_url, version}`. Returns `{ok, service_id,
+    registered_at, last_seen, ...}` or `{ok: false, reason: ...}` on validation
+    failure. Idempotent — re-registering an existing service_id overwrites the
+    URL and bumps `last_seen`.
+    """
+    body = payload or {}
+    service_id = str(body.get("service_id", "")).strip()
+    public_url = str(body.get("public_url", "")).strip()
+    version = str(body.get("version", "1"))
+    reg_log = logging.getLogger("developer_ws")
+    if not service_id:
+        reg_log.warning("register rejected: missing service_id payload=%r", body)
+        return {"ok": False, "reason": "service_id is required"}
+    url_err = _validate_public_url(public_url)
+    if url_err:
+        reg_log.warning(
+            "register rejected: %s service_id=%s public_url=%r",
+            url_err, service_id, public_url,
+        )
+        return {"ok": False, "reason": url_err}
+    entry = developer_service_registry.register(service_id, public_url, version=version)
+    reg_log.info(
+        "register accepted service_id=%s public_url=%s version=%s",
+        entry.service_id, entry.public_url, entry.version,
+    )
+    return {
+        "ok": True,
+        "service_id": entry.service_id,
+        "public_url": entry.public_url,
+        "registered_at": entry.registered_at,
+        "last_seen": entry.last_seen,
+        "version": entry.version,
+    }
+
+
+@app.post("/developer/unregister")
+async def developer_unregister(payload: dict | None = Body(default=None)):
+    """Developer service removes its registration on graceful shutdown.
+
+    Called by: a service's SIGINT/SIGTERM/atexit handler. Idempotent — returns
+    `{ok: true}` whether or not the service was actually registered, so the
+    caller can fire-and-forget without branching on the response.
+    """
+    body = payload or {}
+    service_id = str(body.get("service_id", "")).strip()
+    reg_log = logging.getLogger("developer_ws")
+    if not service_id:
+        reg_log.warning("unregister rejected: missing service_id payload=%r", body)
+        return {"ok": False, "reason": "service_id is required"}
+    removed = developer_service_registry.unregister(service_id)
+    return {"ok": True, "service_id": service_id, "removed": removed}
+
+
+@app.get("/developer/services")
+async def developer_services_list():
+    """Debug endpoint: snapshot of all registered services."""
+    return {
+        "services": [
+            {
+                "service_id":    e.service_id,
+                "public_url":    e.public_url,
+                "registered_at": e.registered_at,
+                "last_seen":     e.last_seen,
+                "version":       e.version,
+            }
+            for e in developer_service_registry.list_all()
+        ],
+    }
+
+
 @app.post("/developer/ping/{user_id}")
 async def developer_ping(user_id: str, payload: dict | None = Body(default=None)):
     """Service-initiated call hook.
@@ -59,9 +154,15 @@ async def developer_ping(user_id: str, payload: dict | None = Body(default=None)
 
     Flow:
       1. Read `service_id` + `version` from the JSON body (if any).
-      2. Look up the live session via `developer_ws.registry.get(user_id)`.
-      3. If a session exists, call `pipeline.on_service_ping(service_id=...)` which
-         speaks the announcement and dials the bridge to `DEVELOPER_WS_REMOTE_BRIDGE_URL`.
+      2. Look up the live user session via `developer_ws.registry.get(user_id)`.
+      3. Look up the developer-service dial URL via
+         `developer_ws.service_registry.get(service_id)`. If unset, the caller
+         likely forgot to POST `/developer/register` first — short-circuit with
+         `reason: "service not registered"`. As a back-compat fallback, if the
+         service_id is unset (older clients), fall through to the legacy
+         `DEVELOPER_WS_REMOTE_BRIDGE_URL` env var that `bridge.py` defaults to.
+      4. Pass the resolved URL into `pipeline.on_service_ping(service_id, public_url)`
+         so the announce-then-bridge flow dials the right place.
     """
     body = payload or {}
     service_id = str(body.get("service_id", "unknown"))
@@ -71,6 +172,23 @@ async def developer_ping(user_id: str, payload: dict | None = Body(default=None)
         "ping received user_id=%s service_id=%s caller_version=%s",
         user_id, service_id, caller_version,
     )
+
+    # Resolve the developer-service dial URL from the service registry.
+    public_url: str | None = None
+    if service_id and service_id != "unknown":
+        public_url = developer_service_registry.get_url(service_id)
+        if public_url is None:
+            ping_log.info(
+                "ping rejected: service not registered user_id=%s service_id=%s",
+                user_id, service_id,
+            )
+            return {
+                "ok": False,
+                "reason": "service not registered",
+                "user_id": user_id,
+                "service_id": service_id,
+            }
+
     pipeline = developer_registry.get(user_id)
     if pipeline is None:
         ping_log.info(
@@ -83,8 +201,13 @@ async def developer_ping(user_id: str, payload: dict | None = Body(default=None)
             "user_id": user_id,
             "service_id": service_id,
         }
-    ok = await pipeline.on_service_ping(service_id=service_id)
-    return {"ok": ok, "user_id": user_id, "service_id": service_id}
+    ok = await pipeline.on_service_ping(service_id=service_id, public_url=public_url)
+    return {
+        "ok": ok,
+        "user_id": user_id,
+        "service_id": service_id,
+        "public_url": public_url,
+    }
 
 if __name__ == "__main__":
     import uvicorn

--- a/test/app/developer/test_service_registry.py
+++ b/test/app/developer/test_service_registry.py
@@ -1,0 +1,177 @@
+"""Unit tests for the developer-service registry (app/developer_ws/service_registry.py)
+and its three HTTP endpoints (/developer/register, /developer/unregister,
+/developer/services) wired in app/main.py.
+
+These tests do not touch the WebSocket plumbing — only the registration map and
+the routes around it. Run with:
+
+    pytest test/app/developer/test_service_registry.py -q
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+
+# Match the import-style used everywhere else in the repo: `app/` is a sys.path root.
+_APP_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "..", "app")
+sys.path.insert(0, os.path.abspath(_APP_DIR))
+
+# Importing app.main has side effects (FastAPI app construction + lifespan model
+# warmups). We don't want the warmups in unit tests; the lifespan only fires when
+# the app actually receives a startup event, which TestClient does on first
+# request. Wrap TestClient in a context manager that mocks out the warmups.
+from unittest.mock import patch  # noqa: E402
+
+with patch("developer_ws.preload_vosk_model"), \
+     patch("developer_ws.preload_piper_voice"):
+    from main import app  # noqa: E402
+    from developer_ws import service_registry  # noqa: E402
+
+
+@pytest.fixture
+def client():
+    """Fresh TestClient + cleared registry per test."""
+    service_registry.clear()
+    with TestClient(app) as c:
+        yield c
+    service_registry.clear()
+
+
+# -------------------- registry module --------------------
+
+def test_register_then_get_returns_url():
+    service_registry.clear()
+    entry = service_registry.register("svc-a", "wss://a.trycloudflare.com/relay")
+    assert entry.service_id == "svc-a"
+    assert entry.public_url == "wss://a.trycloudflare.com/relay"
+    assert service_registry.get_url("svc-a") == "wss://a.trycloudflare.com/relay"
+
+
+def test_register_overwrites_url_on_reregister():
+    service_registry.clear()
+    e1 = service_registry.register("svc-a", "wss://old.example/relay")
+    e2 = service_registry.register("svc-a", "wss://new.example/relay")
+    # Same registered_at (entry persisted), bumped last_seen, new URL.
+    assert e2.registered_at == e1.registered_at
+    assert e2.last_seen >= e1.last_seen
+    assert e2.public_url == "wss://new.example/relay"
+    assert service_registry.get_url("svc-a") == "wss://new.example/relay"
+
+
+def test_unregister_removes_entry():
+    service_registry.clear()
+    service_registry.register("svc-a", "wss://a.example/relay")
+    assert service_registry.unregister("svc-a") is True
+    assert service_registry.get("svc-a") is None
+    # Idempotent: second unregister returns False but doesn't raise.
+    assert service_registry.unregister("svc-a") is False
+
+
+def test_get_returns_none_for_unknown_service():
+    service_registry.clear()
+    assert service_registry.get("nope") is None
+    assert service_registry.get_url("nope") is None
+
+
+# -------------------- HTTP routes --------------------
+
+def test_register_route_accepts_valid_payload(client):
+    r = client.post("/developer/register", json={
+        "service_id": "svc-1", "public_url": "wss://x.trycloudflare.com/relay",
+    })
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is True
+    assert body["service_id"] == "svc-1"
+    assert body["public_url"] == "wss://x.trycloudflare.com/relay"
+    assert body["version"] == "1"
+    assert "registered_at" in body and "last_seen" in body
+
+
+def test_register_route_rejects_missing_service_id(client):
+    r = client.post("/developer/register", json={"public_url": "wss://x/relay"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body == {"ok": False, "reason": "service_id is required"}
+
+
+def test_register_route_rejects_bad_url_scheme(client):
+    r = client.post("/developer/register", json={
+        "service_id": "svc-1", "public_url": "http://x/relay",
+    })
+    body = r.json()
+    assert body["ok"] is False
+    assert "ws://" in body["reason"] or "wss://" in body["reason"]
+
+
+def test_register_route_rejects_empty_url(client):
+    r = client.post("/developer/register", json={"service_id": "svc-1", "public_url": ""})
+    body = r.json()
+    assert body["ok"] is False
+    assert "public_url" in body["reason"]
+
+
+def test_unregister_route_removes_entry(client):
+    client.post("/developer/register", json={
+        "service_id": "svc-1", "public_url": "wss://x/relay",
+    })
+    r = client.post("/developer/unregister", json={"service_id": "svc-1"})
+    assert r.status_code == 200
+    assert r.json() == {"ok": True, "service_id": "svc-1", "removed": True}
+    # Now /developer/services should not list it.
+    listing = client.get("/developer/services").json()
+    assert all(s["service_id"] != "svc-1" for s in listing["services"])
+
+
+def test_unregister_route_is_idempotent(client):
+    r = client.post("/developer/unregister", json={"service_id": "never-existed"})
+    assert r.status_code == 200
+    assert r.json() == {"ok": True, "service_id": "never-existed", "removed": False}
+
+
+def test_unregister_route_rejects_missing_service_id(client):
+    r = client.post("/developer/unregister", json={})
+    body = r.json()
+    assert body == {"ok": False, "reason": "service_id is required"}
+
+
+def test_services_list_endpoint_reflects_registry(client):
+    client.post("/developer/register", json={
+        "service_id": "svc-a", "public_url": "wss://a/relay",
+    })
+    client.post("/developer/register", json={
+        "service_id": "svc-b", "public_url": "wss://b/relay",
+    })
+    listing = client.get("/developer/services").json()
+    ids = sorted(s["service_id"] for s in listing["services"])
+    assert ids == ["svc-a", "svc-b"]
+
+
+def test_ping_returns_service_not_registered_when_unknown(client):
+    # Note: the existing /developer/ping/{user_id} also requires an active
+    # WebSocket user session. The "service not registered" check fires first
+    # whenever service_id is non-empty and absent from the registry, so we hit
+    # that branch without needing a live pipeline.
+    r = client.post("/developer/ping/some-user", json={
+        "service_id": "ghost-svc", "version": "1",
+    })
+    body = r.json()
+    assert body["ok"] is False
+    assert body["reason"] == "service not registered"
+    assert body["service_id"] == "ghost-svc"
+
+
+def test_ping_with_no_service_id_falls_through_to_pipeline_lookup(client):
+    # When service_id is "unknown" (the default when payload omits it), the
+    # service-registry lookup is skipped (back-compat path) and the route
+    # proceeds to check for an active user session. With no live pipeline that
+    # returns "no active session", proving we did NOT short-circuit on the
+    # service registry.
+    r = client.post("/developer/ping/some-user", json={})
+    body = r.json()
+    assert body["ok"] is False
+    assert body["reason"] == "no active session"


### PR DESCRIPTION
## Summary
Orchestrator-side counterpart to [BUILD_SERVICE_PROMPT_V2 (#66)](https://github.com/RishiChandra/agent/pull/66). Adds a `service_id → public_url` registry plus two HTTP endpoints so developer services can self-publish their current dial URL on startup. Replaces the hardcoded `DEVELOPER_WS_REMOTE_BRIDGE_URL` env-var single-target model with a dynamic per-service routing table.

## Architecture
1. **New module** [`app/developer_ws/service_registry.py`](app/developer_ws/service_registry.py) — thread-safe in-memory `service_id → ServiceEntry(public_url, registered_at, last_seen, version)`. Separate from the existing `registry.py` (which keys by `user_id` for live pipelines).
2. **New routes** in [`app/main.py`](app/main.py):
   - `POST /developer/register` — \`{service_id, public_url, version}\`. Validates non-empty `service_id` + `ws://|wss://` scheme. Idempotent re-register bumps `last_seen` (heartbeat-friendly).
   - `POST /developer/unregister` — \`{service_id}\`. Idempotent — returns \`{ok: true, removed: bool}\` whether or not the entry existed.
   - `GET /developer/services` — debug snapshot.
3. **Updated `POST /developer/ping/{user_id}`** —
   - Resolves `service_id → public_url` via the new registry.
   - Returns \`{ok: false, reason: "service not registered"}\` when the `service_id` is non-empty but absent from the registry.
   - Back-compat: if `service_id` is missing / `"unknown"`, skips the registry lookup and falls through to the existing pipeline-lookup path so the `echo_server` test harness keeps working without changes.
   - Passes the resolved `public_url` into `pipeline.on_service_ping(...)`.
4. **`pipeline.on_service_ping()` signature** gains a `public_url` kwarg. Picks `dial_url = public_url or REMOTE_BRIDGE_URL` and logs which source it used (`registry` vs `env-fallback`), so log triage shows which routing path served the call.

## What this unlocks
- A service generated from `BUILD_SERVICE_PROMPT_V2` boots, spawns `cloudflared`, derives a fresh `wss://<random>.trycloudflare.com/relay`, POSTs `/developer/register`, and starts accepting calls — no orchestrator-side config change needed per service.
- Restart → fresh URL → re-register → orchestrator transparently routes new calls to the new URL.
- Service crash → next heartbeat fails to land → operator can detect via `/developer/services` last_seen drift (or layer a sweeper on top later).

## Tests
- 14 new unit tests in [`test/app/developer/test_service_registry.py`](test/app/developer/test_service_registry.py) covering the registry module + the three new routes + the updated ping behaviour. All pass:
  \`\`\`
  test/.venv/bin/python -m pytest test/app/developer/test_service_registry.py -q
  14 passed in 1.30s
  \`\`\`

## Test plan
- [ ] Run the existing echo_server (legacy env-var path) — still bridges correctly (\`service_id\` unset / "unknown" → falls through to env URL)
- [ ] Run a service generated from BUILD_SERVICE_PROMPT_V2 — POSTs \`/developer/register\` on startup, ping resolves the registered URL, bridge dials it
- [ ] Restart that service — fresh tunnel URL, re-registers, next ping routes to the new URL with no orchestrator change
- [ ] Send POST \`/developer/unregister\` — \`GET /developer/services\` confirms it's gone; subsequent ping returns \`reason: "service not registered"\`
- [ ] Concurrent registers from two service_ids resolve independently

## Security note
The endpoints are currently unauthenticated — anyone who can reach the orchestrator can claim any \`service_id\` and redirect its traffic. Documented in the module docstring. A production deployment should layer auth + per-service-id ownership on top (out of scope for this PR; this is the dev/demo enablement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)